### PR TITLE
Fix mixed content issue related to the emoji css

### DIFF
--- a/_site/index.html
+++ b/_site/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Self-Defined &middot; A modern dictionary about us. We define our words, but they don't define us.</title>
     <link rel="stylesheet" href="css/base.css">
-    <link href="https://afeld.github.io/emoji-css/emoji.css" rel="stylesheet">
+    <link href="https://emoji-css.afeld.me/emoji.css" rel="stylesheet">
 </head>
 
   <body>


### PR DESCRIPTION
I'm getting a "Content blocked" notification from my browser when I open selfdefined.app

The console says: `Mixed Content: The page at 'https://www.selfdefined.app/' was loaded over HTTPS, but requested an insecure stylesheet 'http://emoji-css.afeld.me/emoji.css'. This request has been blocked; the content must be served over HTTPS.`

Turns out that the currently used stylesheet, `https://afeld.github.io/emoji-css/emoji.css`, now serves a `301` response redirecting to `http://emoji-css.afeld.me/emoji.css` (insecure!).

In this commit I've replaced it with the new URL, but over HTTPS.