### PR TITLE
🔨 Fix overflowing heading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 dist
 config.codekit3
+.cache

--- a/11ty/index.njk
+++ b/11ty/index.njk
@@ -3,10 +3,8 @@ layout: layouts/index.njk
 ---
 
 <section id="introduction" class="auto-grid">
-      <div id="title">
-        <h1 class="title__thicc">Self-Defined</h1>
-        <p>A modern dictionary about us.<br>We define our words, but they don't define us.</p>
-      </div>
+      <h1 class="title__thicc" id="title">Self-Defined</h1>
+      <p>A modern dictionary about us.<br>We define our words, but they don't define us.</p>
       <div>
         <p class="summary">
           Self-Defined seeks to provide more inclusive, holistic, and fluid definitions to reflect the diverse perspectives of the modern world.

--- a/assets/css/base.scss
+++ b/assets/css/base.scss
@@ -138,12 +138,29 @@ ul[class] {
 }
 
 .title__thicc {
-  font-size: 8vh;
+  // a sensible base font size
+  font-size: 3rem;
   line-height: 0.75;
   padding: 0;
   margin: 0.5rem 0rem;
   // transform: rotateZ(90deg);
   // margin: 13rem -7rem;
+}
+
+@media (min-width: 51rem) and (min-height: 400px) {
+  // a dramatic font size
+  .title__thicc {
+    font-size: 12vh;
+  } 
+}
+
+@media (min-width: 51rem) and (min-height: 850px) {
+  // cap the max-height of the title
+  // at the same size that 12vh computes to
+  // when the viewport is 850px high
+  .title__thicc {
+    font-size: 6.75rem;
+  } 
 }
 
 @media (min-width: 800px) {

--- a/assets/css/base.scss
+++ b/assets/css/base.scss
@@ -142,9 +142,18 @@ ul[class] {
   line-height: 0.75;
   padding: 0;
   margin: 0.5rem 0rem;
-  grid-column: span 2;
   // transform: rotateZ(90deg);
   // margin: 13rem -7rem;
+}
+
+@media (min-width: 800px) {
+  .title__thicc {
+      grid-column: 1 / 3;
+  }
+
+  .title__thicc + p {
+    grid-column: 1 / 2;
+  }
 }
 
 .help {


### PR DESCRIPTION
I’m not usually a Github user, so please forgive me any sins!

My work should help with issue #27:

- Put the intro title and description back into the grid so the title can span multiple columns.
- Made the title scale according to viewport height, but only once the viewport is wide enough and tall enough to handle it. (Also specified a max-height to stop it getting silly big on tall viewports.)

As this title is effectively a logo, I reckon it’s fine to have slightly fiddly typography applied to it, but I’d probably avoid this level of detail on body text.

I’ve made my commits descriptive so I hope they help. The font size of the title is probably personal preference. I do love me some big type, but feel free to adjust if it’s too big on wider viewports! (Or not big enough… that’d be cool…)

Note: I had to add the cache folder to .gitignore. I think this might’ve been done in a previous commit to this repo but somehow reverted during a merge. I also found the ignore `dist` rule ineffective for me. I’m not sure if its a syntax or permissions problem on my machine. (Still I avoided committing any files from the dist folder!)