### PR TITLE
👩‍🎨 Avoid Breaks in Table of Content Items

### DIFF
--- a/11ty/_includes/components/table-of-content-item.njk
+++ b/11ty/_includes/components/table-of-content-item.njk
@@ -1,4 +1,4 @@
-<li>
+<li class="toc__list-item">
   {{ definition.data.title | linkIfExistsInCollection(collections.definedWords) | safe  }}
   {%- if
     definition.data.flag and

--- a/11ty/_includes/components/table-of-content.njk
+++ b/11ty/_includes/components/table-of-content.njk
@@ -1,16 +1,16 @@
 <section>
   <nav class="" aria-label="Definitions">
     <ol class="multi-column u-no-padding-left list">
-    {% for section in collections.tableOfContent %}
-      <li>
-        <span class="sub-headline">{{ section.title }}</span>
-        <ol>
-          {% for definition in section.definitions %}
-            {% include 'components/table-of-content-item.njk' %}
-          {% endfor %}
-        </ol>
-      </li>
-    {% endfor %}
+      {% for section in collections.tableOfContent %}
+        <li>
+          <span class="sub-headline">{{ section.title }}</span>
+          <ol class="toc__list">
+            {% for definition in section.definitions %}
+              {% include 'components/table-of-content-item.njk' %}
+            {% endfor %}
+          </ol>
+        </li>
+      {% endfor %}
     </ol>
   </nav>
 </section>

--- a/assets/css/base.scss
+++ b/assets/css/base.scss
@@ -176,11 +176,7 @@ th {
   grid-gap: var(--l-gap);
 }
 
-.multi-column {
-  column-count: auto;
-  column-gap: var(--l-gap);
-  column-width: var(--auto-grid-min-size);
-}
+@import './structures/multi-column';
 @import './structures/table-of-content';
 
 .small-left-grid {

--- a/assets/css/base.scss
+++ b/assets/css/base.scss
@@ -181,6 +181,7 @@ th {
   column-gap: var(--l-gap);
   column-width: var(--auto-grid-min-size);
 }
+@import './structures/table-of-content';
 
 .small-left-grid {
   display: grid;

--- a/assets/css/structures/_multi-column.scss
+++ b/assets/css/structures/_multi-column.scss
@@ -1,0 +1,5 @@
+.multi-column {
+  column-count: auto;
+  column-gap: var(--l-gap);
+  column-width: var(--auto-grid-min-size);
+}

--- a/assets/css/structures/_table-of-content.scss
+++ b/assets/css/structures/_table-of-content.scss
@@ -1,0 +1,3 @@
+.toc__list-item {
+  page-break-inside: avoid;
+}

--- a/assets/css/structures/_table-of-content.scss
+++ b/assets/css/structures/_table-of-content.scss
@@ -1,3 +1,3 @@
 .toc__list-item {
-  page-break-inside: avoid;
+  break-inside: avoid;
 }


### PR DESCRIPTION
Due to auto-flowing of CSS columns browsers were free to break content inside of a ToC item, or list of subterms. This lead to subterms at the beginning of a column. 

E.g. here is Chrome breaking in the subterms of black:

<img width="517" alt="Snapshot of the multi-column view on the homepage, where the list of subterms is broken in a way that they are disconnected from the main term." src="https://user-images.githubusercontent.com/7645967/72445775-8e571700-37b2-11ea-8cb8-c2eae84ea14e.png">

By using `break-inside: avoid` ([MDN](http://developer.mozilla.org/en-US/docs/Web/CSS/break-inside)) this problem gets fixed.

I also started to create module files for CSS to make it easier to find elements. 