### PR TITLE
🐛 Add aria-label to table of content subterm if it is undefined

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -30,7 +30,7 @@ module.exports = function(config) {
       )}" aria-label="${subTermData.full_title}">${subTermData.text}</a>`;
     }
 
-    return subTermData.text;
+    return `<span aria-label="${subTermData.full_title}">${subTermData.text}</span>`;
   });
 
   // just a debug filter to lazily inspect the content of anything in a template


### PR DESCRIPTION
## Current 

The full title of a sub-term is only added to the item if an existing definition is found. 

## Update

Render a `span` around unlinked elements and add the full title as an `aria-label` to it. With this all list items are announced with the full title and not the at times confusing abbreviated version