### PR TITLE
Add a `pageStyles` block to base template

### DIFF
--- a/11ty/_includes/layouts/base.njk
+++ b/11ty/_includes/layouts/base.njk
@@ -11,7 +11,7 @@
       name="description"
       content="{{ renderData.description or description or metadata.description }}"
     >
-
+    <link rel="stylesheet" href="https://use.typekit.net/qlo3dpu.css"/>
     <link rel="stylesheet" href="{{ '/assets/css/base.css' | url }}">
   </head>
   <body>

--- a/11ty/_includes/layouts/base.njk
+++ b/11ty/_includes/layouts/base.njk
@@ -11,7 +11,7 @@
       name="description"
       content="{{ renderData.description or description or metadata.description }}"
     >
-    <link rel="stylesheet" href="https://use.typekit.net/qlo3dpu.css"/>
+    <link rel="stylesheet" href="https://use.typekit.net/qlo3dpu.css" rel="preload"/>
     <link rel="stylesheet" href="{{ '/assets/css/base.css' | url }}">
     {% block pageStyles %}
     {% endblock pageStyles %}

--- a/11ty/_includes/layouts/base.njk
+++ b/11ty/_includes/layouts/base.njk
@@ -13,6 +13,8 @@
     >
     <link rel="stylesheet" href="https://use.typekit.net/qlo3dpu.css"/>
     <link rel="stylesheet" href="{{ '/assets/css/base.css' | url }}">
+    {% block pageStyles %}
+    {% endblock pageStyles %}
   </head>
   <body>
     {% block content %}{% endblock content %}

--- a/11ty/_includes/layouts/documentation.njk
+++ b/11ty/_includes/layouts/documentation.njk
@@ -1,7 +1,10 @@
 {% extends 'layouts/base.njk' %}
 {% set pageType = 'Page' %}
 {% set titleWithPath = title + ' « Documentation « ' %}
-
+{% block pageStyles %}
+  {# Code highlighting #}
+  <link rel="stylesheet" href="https://unpkg.com/prism-themes@^1.3/themes/prism-a11y-dark.css"/>
+{% endblock %}
 {% block content %}
   <div class="article-content">
     {% include 'components/sub-page-header.njk' %}

--- a/assets/css/base.scss
+++ b/assets/css/base.scss
@@ -21,9 +21,6 @@
 @import 'components/word', 'components/lists', 'components/definitions',
   'components/flag';
 
-// 5.1 Code Highlighting
-@import '~prism-themes/themes/prism-a11y-dark';
-
 // 6. Page-specific styles
 @import './layouts/pages';
 

--- a/assets/css/base/_fonts.scss
+++ b/assets/css/base/_fonts.scss
@@ -1,5 +1,3 @@
-@import url('https://use.typekit.net/qlo3dpu.css');
-
 $sans-serif: monotype-grotesque, 'Lucida Sans', sans-serif;
 $serif: orpheuspro, Palatino, Times, serif;
 $ext-sans: monotype-grotesque-extended, Arial Black, sans-serif;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11252,11 +11252,6 @@
         "parse-ms": "^0.1.0"
       }
     },
-    "prism-themes": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/prism-themes/-/prism-themes-1.3.0.tgz",
-      "integrity": "sha512-4hDQyNuBRyWVvwHeTH4yY5TIWrl6BHmhoh85kgfTFgwklGerWA3R2RFp7Sg0zPCnQS8SsloKsEIN3ao63KhiIw=="
-    },
     "prismjs": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.17.1.tgz",

--- a/package.json
+++ b/package.json
@@ -52,8 +52,7 @@
   "dependencies": {
     "@11ty/eleventy": "^0.10.0",
     "markdown-it-anchor": "^5.2.5",
-    "markdown-it-prism": "^2.0.3",
-    "prism-themes": "^1.3.0"
+    "markdown-it-prism": "^2.0.3"
   },
   "devDependencies": {
     "ava": "^3.5.0",


### PR DESCRIPTION
Also: 
- Imports the TypeKit font bundle as a link in the base template
- Imports the `prism-a11y-dark` theme as a link in only the documentation template 

Importing these external stylesheets bundle as links will improve UX because css `@import`s are render-blocking, while `<link>` imports are not. Since most users spend time on the main page, moving the prism link to the documentation template will prevent unnecessary downloads.

Importing the TypeKit bundle as a link will also make #97 (Load fonts progressively) possible