### PR TITLE
Fix stylelint error

### DIFF
--- a/assets/css/structures/_grid.scss
+++ b/assets/css/structures/_grid.scss
@@ -57,11 +57,11 @@
 .box {
   background: black;
   color: white;
+  grid-column: span 2;
   height: auto;
   margin: 1rem 0.5rem;
   padding: 1rem;
-  grid-column: span 2;
-  
+
   a {
     color: white;
   }


### PR DESCRIPTION
This error was preventing me from building and pushing, albeit inconsistently:
```
assets/css/structures/_grid.scss
 63:3  ✖  Expected grid-column to come before padding   order/properties-alphabetical-order
```

This PR  moves some styles around to satisfy the alphabetical-order rule.