### PR TITLE
Import fonts with rel=preload polyfill

### DIFF
--- a/11ty/_includes/layouts/base.njk
+++ b/11ty/_includes/layouts/base.njk
@@ -11,7 +11,9 @@
       name="description"
       content="{{ renderData.description or description or metadata.description }}"
     >
-    <link rel="stylesheet" href="https://use.typekit.net/qlo3dpu.css" rel="preload"/>
+
+    <link rel="preload" href="https://use.typekit.net/qlo3dpu.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
+    <noscript><link rel="stylesheet" href="https://use.typekit.net/qlo3dpu.css"></noscript>
     <link rel="stylesheet" href="{{ '/assets/css/base.css' | url }}">
     {% block pageStyles %}
     {% endblock pageStyles %}
@@ -27,6 +29,9 @@
         </ul>
       </nav>
     </footer>
+    {# rel=preload polyfill #}
+    {# see: https://github.com/filamentgroup/loadCSS #}
+    <script>!function(t){"use strict";t.loadCSS||(t.loadCSS=function(){});var e=loadCSS.relpreload={};if(e.support=function(){var e;try{e=t.document.createElement("link").relList.supports("preload")}catch(t){e=!1}return function(){return e}}(),e.bindMediaToggle=function(t){var e=t.media||"all";function a(){t.addEventListener?t.removeEventListener("load",a):t.attachEvent&&t.detachEvent("onload",a),t.setAttribute("onload",null),t.media=e}t.addEventListener?t.addEventListener("load",a):t.attachEvent&&t.attachEvent("onload",a),setTimeout(function(){t.rel="stylesheet",t.media="only x"}),setTimeout(a,3e3)},e.poly=function(){if(!e.support())for(var a=t.document.getElementsByTagName("link"),n=0;n<a.length;n++){var o=a[n];"preload"!==o.rel||"style"!==o.getAttribute("as")||o.getAttribute("data-loadcss")||(o.setAttribute("data-loadcss",!0),e.bindMediaToggle(o))}},!e.support()){e.poly();var a=t.setInterval(e.poly,500);t.addEventListener?t.addEventListener("load",function(){e.poly(),t.clearInterval(a)}):t.attachEvent&&t.attachEvent("onload",function(){e.poly(),t.clearInterval(a)})}"undefined"!=typeof exports?exports.loadCSS=loadCSS:t.loadCSS=loadCSS}("undefined"!=typeof global?global:this);</script>
     {% block pageScript %}
     {% endblock pageScript %}
   </body>


### PR DESCRIPTION
Closes #97 (Load fonts progressively)

This approach directly copies an inline, minified version of the rel="preload" polyfill to the bottom of the `base.njk` template, per Filament Group's suggestion. A less-fragile future approach might be to:
- Add fg-loadcss as a dependency
- copy the contents of the minified js file at build time
- inline the js file into `base.njk` with something like [this filter](https://www.11ty.dev/docs/quicktips/inline-js/)