### PR TITLE
Add "temperature check" alt to "sanity check"

### DIFF
--- a/11ty/definitions/sanity-check.md
+++ b/11ty/definitions/sanity-check.md
@@ -14,8 +14,8 @@ alt_words:
   - initial check
   - quick check
   - sense check
-  - temperature check
   - smoke test
+  - temperature check
   - soundness check
   - spot check
 reading:

--- a/11ty/definitions/sanity-check.md
+++ b/11ty/definitions/sanity-check.md
@@ -14,6 +14,7 @@ alt_words:
   - initial check
   - quick check
   - sense check
+  - temperature check
   - smoke test
   - soundness check
   - spot check


### PR DESCRIPTION
## Motivation

"temperature check" is the alternative I've been using personally, and I think it adds some minor value to have it here!

## Usage Comparison

"temperature check" is very similar to the existing "smoke test" alternative, but I think it's different enough to callout separately. For example, here's two distinct ways that I would use the two phrases:

- I stood up a quick PR to fix a bug I found, can you give it a _temperature check_?
- The code just pushed to prod has a very large diff, can we run a _smoke test_ on it?

## Reviewer Guidance

"temperature check" and "smoke test" are close enough in meaning that this might not be a valuable addition. So I wouldn't be offended if this PR wasn't accepted 🙂 