### PR TITLE
definitions/gender-pronouns: Fix onwards link to 'pronouns'

### DIFF
--- a/11ty/definitions/gender-pronouns.md
+++ b/11ty/definitions/gender-pronouns.md
@@ -4,7 +4,7 @@ slug: gender-pronouns
 defined: true
 ---
 
-gender pronouns are often used to mean [pronouns](/definition/pronouns).
+gender pronouns are often used to mean [pronouns](/definitions/pronouns).
 
 ## Issue
 


### PR DESCRIPTION
- First of all, thanks for building SelfDefined! <3
- The pronouns link was missing an 's' on 'definitions/...' and gave a 404.
- I searched for other occurrences of this and didn't find any. :tada:
