### PR TITLE
Feature/rss feed

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,6 +1,7 @@
 const definitionPermalink = require('./11ty/helpers/definitionPermalink');
 const renderDefinitionContentNextEntries = require('./11ty/shortcodes/renderDefinitionContentNextEntries');
 const findExistingDefinition = require('./11ty/filters/helpers/findExistingDefinition');
+const pluginRss = require('@11ty/eleventy-plugin-rss');
 
 module.exports = function(config) {
   // Add a filter using the Config API
@@ -37,6 +38,8 @@ module.exports = function(config) {
   config.addFilter('postInspect', function(post) {
     console.log(post);
   });
+
+  config.addPlugin(pluginRss);
 
   config.addShortcode('definitionFlag', (flag) => {
     const cleanText = new Map([

--- a/11ty/_data/metadata.json
+++ b/11ty/_data/metadata.json
@@ -1,6 +1,7 @@
 {
   "title": "Self-Defined",
   "url": "https://www.selfdefined.app/",
+  "feedPermalink": "/feed.xml",
   "description": "A modern dictionary about us. We define our words, but they don't define us.",
   "author": {
     "name": "Tatiana & the Crew",

--- a/11ty/_data/metadata.json
+++ b/11ty/_data/metadata.json
@@ -5,6 +5,7 @@
   "description": "A modern dictionary about us. We define our words, but they don't define us.",
   "author": {
     "name": "Tatiana & the Crew",
+    "name_safe": "Tatiana &amp; the Crew",
     "email": "info@selfdefined.app"
   }
 }

--- a/11ty/_includes/layouts/base.njk
+++ b/11ty/_includes/layouts/base.njk
@@ -13,6 +13,7 @@
     >
     <link rel="stylesheet" href="https://use.typekit.net/qlo3dpu.css" rel="preload"/>
     <link rel="stylesheet" href="{{ '/assets/css/base.css' | url }}">
+    <link rel="alternate" type="application/atom+xml" href="{{ metadata.feedPermalink | absoluteUrl(metadata.url) }}"/>
     {% block pageStyles %}
     {% endblock pageStyles %}
   </head>

--- a/11ty/definitions/-misia.md
+++ b/11ty/definitions/-misia.md
@@ -16,7 +16,7 @@ reading:
   - text: "Anti-Oppression: Anti-Fatmisia"
     href: https://simmons.libguides.com/anti-oppression/anti-fatmisia
 ---
----
+
 from Greek for hate or hatred
 
 ## Use

--- a/11ty/definitions/derpy.md
+++ b/11ty/definitions/derpy.md
@@ -30,7 +30,7 @@ derp, derp face, herp derp, hurr durr
 
 Derpy is very commonly used as an adjective to describe someone's clumsy or foolish behavior, occasionally that of the speaker themselves. Sometimes it is used as a direct replacement of the [r-word](https://www.selfdefined.app/definitions/r-word/).
 
-It is also used to describe someone else's physical features as unattractive or akin to someone with intellectual and developmental disabilities. In imagery, derpy or a so-called "derp face", is often signified by crossed eyes, a stuck out tongue, or permanent facial differences. 
+It is also used to describe someone else's physical features as unattractive or akin to someone with intellectual and developmental disabilities. In imagery, derpy or a so-called "derp face", is often signified by crossed eyes, a stuck out tongue, or permanent facial differences.
 
 ## Origins
 

--- a/11ty/definitions/derpy.md
+++ b/11ty/definitions/derpy.md
@@ -23,6 +23,7 @@ reading:
 clumsy, foolish, unattractive, or otherwise unintelligent act or person.
 
 ## Related Words
+
 derp, derp face, herp derp, hurr durr
 
 ## Issues

--- a/11ty/definitions/derpy.md
+++ b/11ty/definitions/derpy.md
@@ -14,10 +14,10 @@ alt_words:
   - malformed
   - silly
 reading:
- - text: Derp is ableist and offensive
-   href: https://americandramedy.blogspot.com/2013/06/derp-is-ableist-and-offensive-stop.html
- - text: Ableist words and terms to avoid
-   href: https://www.autistichoya.com/p/ableist-words-and-terms-to-avoid.html
+  - text: Derp is ableist and offensive
+    href: https://americandramedy.blogspot.com/2013/06/derp-is-ableist-and-offensive-stop.html
+  - text: Ableist words and terms to avoid
+    href: https://www.autistichoya.com/p/ableist-words-and-terms-to-avoid.html
 ---
 
 clumsy, foolish, unattractive, or otherwise unintelligent act or person.

--- a/11ty/feed.njk
+++ b/11ty/feed.njk
@@ -8,13 +8,13 @@
   <subtitle>{{ metadata.subtitle }}</subtitle>
   <link href="{{ metadata.feedUrl }}" rel="self"/>
   <link href="{{ metadata.url }}"/>
-  <updated>{{ collections.posts | rssLastUpdatedDate }}</updated>
+  <updated>{{ collections.definedWords | rssLastUpdatedDate }}</updated>
   <id>{{ metadata.url }}</id>
   <author>
     <name>{{ metadata.author.name }}</name>
     <email>{{ metadata.author.email }}</email>
   </author>
-  {%- for post in collections.posts %}
+  {%- for post in collections.definedWords %}
   {% set absolutePostUrl %}{{ post.url | url | absoluteUrl(metadata.url) }}{% endset %}
   <entry>
     <title>{{ post.data.title }}</title>

--- a/11ty/feed.njk
+++ b/11ty/feed.njk
@@ -6,7 +6,7 @@
 <feed xmlns="http://www.w3.org/2005/Atom">
   <title>{{ metadata.title }}</title>
   <subtitle>{{ metadata.subtitle }}</subtitle>
-  <link href="{{ metadata.feedUrl }}" rel="self"/>
+  <link href="{{ metadata.feedPermalink | absoluteUrl(metadata.url) }}" rel="self"/>
   <link href="{{ metadata.url }}"/>
   <updated>{{ collections.definedWords | rssLastUpdatedDate }}</updated>
   <id>{{ metadata.url }}</id>

--- a/11ty/feed.njk
+++ b/11ty/feed.njk
@@ -1,0 +1,27 @@
+---
+  permalink: "feed.xml"
+  eleventyExcludeFromCollections: true
+---
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>{{ metadata.title }}</title>
+  <subtitle>{{ metadata.subtitle }}</subtitle>
+  <link href="{{ metadata.feedUrl }}" rel="self"/>
+  <link href="{{ metadata.url }}"/>
+  <updated>{{ collections.posts | rssLastUpdatedDate }}</updated>
+  <id>{{ metadata.url }}</id>
+  <author>
+    <name>{{ metadata.author.name }}</name>
+    <email>{{ metadata.author.email }}</email>
+  </author>
+  {%- for post in collections.posts %}
+  {% set absolutePostUrl %}{{ post.url | url | absoluteUrl(metadata.url) }}{% endset %}
+  <entry>
+    <title>{{ post.data.title }}</title>
+    <link href="{{ absolutePostUrl }}"/>
+    <updated>{{ post.date | rssDate }}</updated>
+    <id>{{ absolutePostUrl }}</id>
+    <content type="html">{{ post.templateContent | htmlToAbsoluteUrls(absolutePostUrl) }}</content>
+  </entry>
+  {%- endfor %}
+</feed>

--- a/11ty/feed.njk
+++ b/11ty/feed.njk
@@ -5,13 +5,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
   <title>{{ metadata.title }}</title>
-  <subtitle>{{ metadata.subtitle }}</subtitle>
+  <subtitle>{{ metadata.description }}</subtitle>
   <link href="{{ metadata.feedPermalink | absoluteUrl(metadata.url) }}" rel="self"/>
   <link href="{{ metadata.url }}"/>
   <updated>{{ collections.definedWords | rssLastUpdatedDate }}</updated>
   <id>{{ metadata.url }}</id>
   <author>
-    <name>{{ metadata.author.name }}</name>
+    <name>{{ metadata.author.name_safe }}</name>
     <email>{{ metadata.author.email }}</email>
   </author>
   {%- for post in collections.definedWords %}

--- a/11ty/index.njk
+++ b/11ty/index.njk
@@ -19,6 +19,7 @@ layout: layouts/index.njk
           <li>Submit words and definitions or contribute to our code base through <a href="https://github.com/tatianamac/selfdefined/pulls" rel="noreferral">pull requests</a> or <a href="https://github.com/tatianamac/selfdefined/issues" rel="noreferral">issues</a>. Start with our <a href="https://github.com/tatianamac/selfdefined/blob/master/CONTRIBUTING.md" rel="noreferral">contributing guidelines</a> and <a href="/documentation/">documentation</a>.</li>
           <li>Sponsor this work through <a href="https://opencollective.com/selfdefined">Open Collective</a> or <a href="https://github.com/sponsors/tatianamac">GitHub Sponsors</a>.</li>
           <li>Follow us on Twitter <a href="https://www.twitter.com/selfdefinedapp">@SelfDefinedApp</a>.</li>
+          <li><a href="{{ metadata.feedPermalink | absoluteUrl(metadata.url) }}">Subscribe</a> in your favorite feed reader.</li>
         </ol>
       </div>
       </section>

--- a/package-lock.json
+++ b/package-lock.json
@@ -216,6 +216,17 @@
         }
       }
     },
+    "@11ty/eleventy-plugin-rss": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy-plugin-rss/-/eleventy-plugin-rss-1.0.7.tgz",
+      "integrity": "sha512-fP06UhcOn45XfXBpAkDL0VlsOQ9poCK+BbdSwhmsYaqJzYVf9whIdRwqX0FUaSy1659bQC8auaXNyGsJQUq87w==",
+      "requires": {
+        "debug": "^4.1.1",
+        "luxon": "^1.0.0",
+        "posthtml": "^0.11.2",
+        "posthtml-urls": "1.0.0"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
@@ -1566,6 +1577,11 @@
       "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz",
       "integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==",
       "dev": true
+    },
+    "any-promise": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-0.1.0.tgz",
+      "integrity": "sha1-gwtoCqflbzNFHUsEnzvYBESY7ic="
     },
     "anymatch": {
       "version": "2.0.0",
@@ -4865,7 +4881,6 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
       "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
-      "dev": true,
       "requires": {
         "domelementtype": "^2.0.1",
         "entities": "^2.0.0"
@@ -4874,14 +4889,12 @@
         "domelementtype": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
-          "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==",
-          "dev": true
+          "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ=="
         },
         "entities": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
-          "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==",
-          "dev": true
+          "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw=="
         }
       }
     },
@@ -4894,8 +4907,7 @@
     "domelementtype": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
-      "dev": true
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
     },
     "domexception": {
       "version": "1.0.1",
@@ -4910,7 +4922,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
       "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
-      "dev": true,
       "requires": {
         "domelementtype": "1"
       }
@@ -4919,7 +4930,6 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
       "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
-      "dev": true,
       "requires": {
         "dom-serializer": "0",
         "domelementtype": "1"
@@ -7063,7 +7073,6 @@
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
       "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
-      "dev": true,
       "requires": {
         "domelementtype": "^1.3.1",
         "domhandler": "^2.3.0",
@@ -7077,7 +7086,6 @@
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
           "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
-          "dev": true,
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -7091,6 +7099,11 @@
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
       "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
       "dev": true
+    },
+    "http-equiv-refresh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/http-equiv-refresh/-/http-equiv-refresh-1.0.0.tgz",
+      "integrity": "sha1-jsU4hmBCvl8/evpzfRmNlL6xsHs="
     },
     "http-errors": {
       "version": "1.7.3",
@@ -8596,6 +8609,11 @@
       "version": "6.4.3",
       "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-6.4.3.tgz",
       "integrity": "sha512-m1xSB10Ncu22NR3X0xdaqu/GvP1xadDCFYGqGgd6me8DAWjyA68BKE5DHJmSxw1CGsWPsX+Hj2v/87J2w/LvMQ=="
+    },
+    "list-to-array": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/list-to-array/-/list-to-array-1.1.0.tgz",
+      "integrity": "sha1-yn3/ZAYGQzysdcvoRGrNhksVv28="
     },
     "listr": {
       "version": "0.14.3",
@@ -10337,6 +10355,11 @@
       "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-0.1.2.tgz",
       "integrity": "sha1-3T+iXtbC78e93hKtm0bBY6opIk4="
     },
+    "parse-srcset": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+      "integrity": "sha1-8r0iH2zJcKk42IVWq8WJyqqiveE="
+    },
     "parse5": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
@@ -11287,7 +11310,6 @@
       "version": "0.11.6",
       "resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.11.6.tgz",
       "integrity": "sha512-C2hrAPzmRdpuL3iH0TDdQ6XCc9M7Dcc3zEW5BLerY65G4tWWszwv6nG/ksi6ul5i2mx22ubdljgktXCtNkydkw==",
-      "dev": true,
       "requires": {
         "posthtml-parser": "^0.4.1",
         "posthtml-render": "^1.1.5"
@@ -11297,7 +11319,6 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.4.2.tgz",
       "integrity": "sha512-BUIorsYJTvS9UhXxPTzupIztOMVNPa/HtAm9KHni9z6qEfiJ1bpOBL5DfUOL9XAc3XkLIEzBzpph+Zbm4AdRAg==",
-      "dev": true,
       "requires": {
         "htmlparser2": "^3.9.2"
       }
@@ -11305,8 +11326,18 @@
     "posthtml-render": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-1.1.5.tgz",
-      "integrity": "sha512-yvt54j0zCBHQVEFAuR+yHld8CZrCa/E1Z/OcFNCV1IEWTLVxT8O7nYnM4IIw1CD4r8kaRd3lc42+0lgCKgm87w==",
-      "dev": true
+      "integrity": "sha512-yvt54j0zCBHQVEFAuR+yHld8CZrCa/E1Z/OcFNCV1IEWTLVxT8O7nYnM4IIw1CD4r8kaRd3lc42+0lgCKgm87w=="
+    },
+    "posthtml-urls": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/posthtml-urls/-/posthtml-urls-1.0.0.tgz",
+      "integrity": "sha512-CMJ0L009sGQVUuYM/g6WJdscsq6ooAwhUuF6CDlYPMLxKp2rmCYVebEU+wZGxnQstGJhZPMvXsRhtqekILd5/w==",
+      "requires": {
+        "http-equiv-refresh": "^1.0.0",
+        "list-to-array": "^1.1.0",
+        "parse-srcset": "^1.0.2",
+        "promise-each": "^2.2.0"
+      }
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -11400,6 +11431,14 @@
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "requires": {
         "asap": "~2.0.3"
+      }
+    },
+    "promise-each": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/promise-each/-/promise-each-2.2.0.tgz",
+      "integrity": "sha1-M1MXTv8mlEgQN+BOAfd6oPttG2A=",
+      "requires": {
+        "any-promise": "^0.1.0"
       }
     },
     "proto-list": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   },
   "dependencies": {
     "@11ty/eleventy": "^0.10.0",
+    "@11ty/eleventy-plugin-rss": "^1.0.7",
     "markdown-it-anchor": "^5.2.5",
     "markdown-it-prism": "^2.0.3"
   },


### PR DESCRIPTION
- introduced the [`@11ty/eleventy-plugin-rss` plugin](https://github.com/11ty/eleventy-plugin-rss)
- copied over the [sample feed template](https://www.11ty.dev/docs/plugins/rss/#sample-atom-feed-template)
- for easy access, there is a link to the feed in the "ways to help" CTA box (as well as a <link> tag in the <head>
![Screen Shot 2020-05-21 at 4 45 38 PM](https://user-images.githubusercontent.com/17733565/82616634-a258be00-9b82-11ea-9539-93b090aef18b.png)
- configured the sample feed template for the Self Defined app structure
- removed redundant `---` i noticed in the `-misia` definition because it rendered an `<hr>` that no other posts had, and XML was not happy
- confirmed no linter errors
- confirmed all tests pass

## please note:
- url for site root (https://selfdefined.app) is hardcoded via the metadata, so testing on localhost requires swapping `https://selfdefined.app` for `localhost:[port]` for testing feed links
- XML was super picky and the validator lit up on the rendered post content, despite a `type="html"` attribute on the `<content>` tag. I played around with using [CDATA tags](https://stackoverflow.com/questions/4412395/is-it-possible-to-insert-html-content-in-xml-document), which then surfaced other nit-picky XML validation errors. I chased this down for a while, before just backing out. I'm open to tips and recommendations on the XML if anyone has ideas. despite the validator warnings/errors, I can confirm the feed still works in a feed reader (shown below using Reeder for macOS)
![Screen-Recording-2020-05-21-at-4](https://user-images.githubusercontent.com/17733565/82617016-aa652d80-9b83-11ea-97d5-4b8d67afc6d5.gif)