### PR TITLE
fixed definition content padding & capitalized FL on homepage list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 config.codekit3
 .cache
 .sass-cache
+.idea

--- a/assets/css/abstracts/_mixins.scss
+++ b/assets/css/abstracts/_mixins.scss
@@ -14,10 +14,6 @@
   content: '🧰';
 }
 
-@mixin icon__hanging() {
-  margin-left: -2.15rem;
-}
-
 @mixin icon__embed() {
   margin-right: 0.35rem;
 }

--- a/assets/css/base.scss
+++ b/assets/css/base.scss
@@ -1,4 +1,4 @@
-@charset 'UTF-8';
+@charset "UTF-8";
 
 // 1. Configuration and helpers
 @import 'abstracts/variables', 'abstracts/functions', 'abstracts/mixins',

--- a/assets/css/components/_word.scss
+++ b/assets/css/components/_word.scss
@@ -78,7 +78,6 @@
 
       &:before {
         @include icon__avoid();
-        @include icon__hanging();
       }
     }
 
@@ -87,21 +86,18 @@
 
       &:before {
         @include icon__alt();
-        @include icon__hanging();
       }
     }
 
     &--tool {
       &:before {
         @include icon__tool();
-        @include icon__hanging();
       }
     }
     &--warning {
       --word-signal-color: $dark-yellow;
       &:before {
         @include icon__warning();
-        @include icon__hanging();
       }
     }
   }

--- a/assets/css/structures/_definition-content.scss
+++ b/assets/css/structures/_definition-content.scss
@@ -77,7 +77,6 @@
     font-family: $ext-sans;
     font-size: 0.75rem;
     letter-spacing: 0.15rem;
-    padding: 0.5rem 0.75rem;
     text-transform: uppercase;
 
     &--avoid {
@@ -85,7 +84,6 @@
 
       &:before {
         @include icon__avoid();
-        @include icon__hanging();
       }
     }
 
@@ -94,14 +92,12 @@
 
       &:before {
         @include icon__alt();
-        @include icon__hanging();
       }
     }
 
     &--tool {
       &:before {
         @include icon__tool();
-        @include icon__hanging();
       }
     }
 
@@ -110,7 +106,6 @@
 
       &:before {
         @include icon__warning();
-        @include icon__hanging();
       }
     }
   }

--- a/assets/css/structures/_grid.scss
+++ b/assets/css/structures/_grid.scss
@@ -77,6 +77,9 @@
   li {
     margin: 0.75rem 0;
   }
+  li:first-letter {
+    text-transform: capitalize;
+  }
   a {
     word-break: break-word;
   }


### PR DESCRIPTION
I noticed that the label before the word is beyond the boundaries of the layout. Now:
![image](https://user-images.githubusercontent.com/3135646/83166198-5ed8f380-a130-11ea-898c-ca31635db6e5.png)
Fixed:
![image](https://user-images.githubusercontent.com/3135646/83166368-a5c6e900-a130-11ea-81e3-975c7163d504.png)


I also made all the words of the dictionary on the main page with a capital letter. Now different words are written with a different capital letter, which, in my opinion, can be misleading:
![image](https://user-images.githubusercontent.com/3135646/83166557-e9b9ee00-a130-11ea-94d4-346888d12dc6.png)
Fixed:
![image](https://user-images.githubusercontent.com/3135646/83166606-ff2f1800-a130-11ea-9f68-e4ee908a861c.png)
