### PR TITLE
Adding preconnect and dns-prefetch hints in header for TypeKit hosts.

### DIFF
--- a/11ty/_includes/layouts/base.njk
+++ b/11ty/_includes/layouts/base.njk
@@ -1,9 +1,12 @@
 <!doctype html>
 <html lang="en">
   <head>
+    <link rel="preconnect" href="https://use.typekit.net/" crossorigin />
+    <link rel="dns-prefetch" href="https://use.typekit.net/" />
+    <link rel="preconnect" href="https://p.typekit.net/" crossorigin />
+    <link rel="dns-prefetch" href="https://p.typekit.net/" />
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-
     {# Use title with path, or append a space to the page title to avoid collpasing with the meta title #}
     {% set pageTitle = titleWithPath or title + ' ' or '' %}
     <title>{{ pageTitle + metadata.title }}</title>
@@ -11,7 +14,7 @@
       name="description"
       content="{{ renderData.description or description or metadata.description }}"
     >
-    <link rel="stylesheet" href="https://use.typekit.net/qlo3dpu.css" rel="preload"/>
+    <link rel="stylesheet" href="https://use.typekit.net/qlo3dpu.css" />
     <link rel="stylesheet" href="{{ '/assets/css/base.css' | url }}">
     {% block pageStyles %}
     {% endblock pageStyles %}


### PR DESCRIPTION
This PR adds `preconnect` and `dns-prefetch` headers to the document `<head>` for TypeKit hosts. These hints will establish a connection to the both use.typekit.com and p.typekit.com as soon as the browser is able to instead of at discovery time. This will not yield much of an improvement for loading content from use.typekit.com, but a connection to p.typekit.com at current is not initiated until it is discovered in the CSS resource served from use.typekit.com:

![WebPageTest waterfall for selfdefined.app without resource hints](https://user-images.githubusercontent.com/1635238/83702451-5d954400-a5d2-11ea-8cc4-580131e405e4.png)

By adding these resource hints, we should be able to move DNS resolution, connection negotiation, and TLS negotiation further up in the process, ensuring less delay in both CSS and font loading from TypeKit. I can run a followup test once the changes are pushed.