### PR TITLE
Fix broken links in readme by using prod branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Netlify Status](https://api.netlify.com/api/v1/badges/82274e91-8f6a-474e-9b2a-fca29bb72d75/deploy-status)](https://app.netlify.com/sites/selfdefined/deploys)
 
-[Contributing Guidelines](https://github.com/tatianamac/selfdefined/blob/master/CONTRIBUTING.md) · [Documentation](https://www.selfdefined.app/documentation/) · [Code of Conduct](https://github.com/tatianamac/selfdefined/blob/master/CODE-OF-CONDUCT.md)
+[Contributing Guidelines](https://github.com/tatianamac/selfdefined/blob/prod/CONTRIBUTING.md) · [Documentation](https://www.selfdefined.app/documentation/) · [Code of Conduct](https://github.com/tatianamac/selfdefined/blob/prod/CODE-OF-CONDUCT.md)
 
 A modern dictionary about us. We define our words, but they don't define us.
 
@@ -22,11 +22,11 @@ We want to create and to foster a welcoming, inclusive, and safer environment wh
 
 ### Code of Conduct
 
-We have adapted the [Contributor Convenent](https://github.com/tatianamac/selfdefined/blob/master/CODE-OF-CONDUCT.md) and expect any contributors to adhere to it. We as maintainers reserve the right to ban anyone's participation who does not foster the welcoming, inclusive, and safer environment we seek to maintain.
+We have adapted the [Contributor Convenent](https://github.com/tatianamac/selfdefined/blob/prod/CODE-OF-CONDUCT.md) and expect any contributors to adhere to it. We as maintainers reserve the right to ban anyone's participation who does not foster the welcoming, inclusive, and safer environment we seek to maintain.
 
 ### Contributing Guide
 
-Please read our [Contributing Guidelines](https://github.com/tatianamac/selfdefined/blob/master/CONTRIBUTING.md) to get started.
+Please read our [Contributing Guidelines](https://github.com/tatianamac/selfdefined/blob/prod/CONTRIBUTING.md) to get started.
 
 ### Documentation
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ We have adapted the [Contributor Convenent](https://github.com/selfdefined/web-a
 
 ### Contributing Guide
 
-Please read our [Contributing Guidelines](https://github.com/tatianamac/selfdefined/blob/prod/CONTRIBUTING.md) to get started.
+Please read our [Contributing Guidelines](https://github.com/selfdefined/web-app/blob/prod/CONTRIBUTING.md) to get started.
 
 ### Documentation
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ We want to create and to foster a welcoming, inclusive, and safer environment wh
 
 ### Code of Conduct
 
-We have adapted the [Contributor Convenent](https://github.com/tatianamac/selfdefined/blob/prod/CODE-OF-CONDUCT.md) and expect any contributors to adhere to it. We as maintainers reserve the right to ban anyone's participation who does not foster the welcoming, inclusive, and safer environment we seek to maintain.
+We have adapted the [Contributor Convenent](https://github.com/selfdefined/web-app/blob/prod/CODE-OF-CONDUCT.md) and expect any contributors to adhere to it. We as maintainers reserve the right to ban anyone's participation who does not foster the welcoming, inclusive, and safer environment we seek to maintain.
 
 ### Contributing Guide
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Netlify Status](https://api.netlify.com/api/v1/badges/82274e91-8f6a-474e-9b2a-fca29bb72d75/deploy-status)](https://app.netlify.com/sites/selfdefined/deploys)
 
-[Contributing Guidelines](https://github.com/tatianamac/selfdefined/blob/prod/CONTRIBUTING.md) · [Documentation](https://www.selfdefined.app/documentation/) · [Code of Conduct](https://github.com/tatianamac/selfdefined/blob/prod/CODE-OF-CONDUCT.md)
+[Contributing Guidelines](https://github.com/selfdefined/web-app/blob/prod/CONTRIBUTING.md) · [Documentation](https://www.selfdefined.app/documentation/) · [Code of Conduct](https://github.com/selfdefined/web-app/blob/prod/CODE-OF-CONDUCT.md)
 
 A modern dictionary about us. We define our words, but they don't define us.
 


### PR DESCRIPTION
Some links in the readme needed to be updated as they pointed to an older branch that existed before the prod branch. This patch fixes those links and allow the hyperlinks to work once again 😄 