### PR TITLE
Add optional category support for alt words.

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -38,6 +38,10 @@ module.exports = function(config) {
     console.log(post);
   });
 
+  config.addFilter('isArray', function(thing) {
+    return Array.isArray(thing);
+  });
+
   config.addShortcode('definitionFlag', (flag) => {
     const cleanText = new Map([
       [

--- a/11ty/_includes/components/definition-content.njk
+++ b/11ty/_includes/components/definition-content.njk
@@ -1,16 +1,40 @@
+{% macro renderAltWords(words, labels) %}
+  {%- if words | isArray -%}
+    {# Array #}
+    <ul
+      class="list-semicolon"
+      {% if labels %}aria-labelledby="{{ labels | join(' ') }}"{% endif %}
+    >
+      {%- for word in words -%}
+        <li>
+          {{ word | linkIfExistsInCollection(collections.definedWords) | safe }}
+        </li>
+      {%- endfor -%}
+    </ul>
+  {%- else -%}
+    {# Object #}
+    {# With class="", the list loses padding via the CSS reset style. #}
+    {# For multi-level category support, we may want an actual class. #}
+    <ul class="">
+      {%- for category, list in words -%}
+        <li>
+          {% set categoryId = ("alt-words-" + category) | replace(' ', '-') %}
+          <strong id="{{ categoryId }}">{{ category }}</strong>
+          {{ renderAltWords(list, labels.concat(categoryId)) }}
+        </li>
+      {%- endfor -%}
+    </ul>
+  {%- endif -%}
+{% endmacro %}
+
 <section class="definition-content">
   <section class="definition-content__content">
     {{ content | safe }}
-    {# <p>{{ alt_words }}</p> #}
   </section>
   {%- if alt_words -%}
     <section class="definition-content__content">
       <h2 id="alt-words">Alt Words</h2>
-      <ul class="list-semicolon" aria-labelledby="alt-words">
-        {% for word in alt_words %}
-          <li>{{ word | linkIfExistsInCollection(collections.definedWords) | safe }}</li>
-        {% endfor %}
-      </ul>
+      {{ renderAltWords(alt_words, ["alt-words"]) }}
     </section>
   {% endif %}
   {%- if reading -%}

--- a/11ty/definitions/digital-blackface.md
+++ b/11ty/definitions/digital-blackface.md
@@ -4,13 +4,13 @@ slug: digital-blackface
 defined: true
 Speech: noun
 reading:
-- text: We Need to Talk About Digital Blackface in Reaction GIFs
-  href: https://www.teenvogue.com/story/digital-blackface-reaction-gifs
-- text: Memes and Misogynoir
-  href: https://www.theawl.com/2014/08/memes-and-misogynoir/
+  - text: We Need to Talk About Digital Blackface in Reaction GIFs
+    href: https://www.teenvogue.com/story/digital-blackface-reaction-gifs
+  - text: Memes and Misogynoir
+    href: https://www.theawl.com/2014/08/memes-and-misogynoir/
 ---
-a form of appropriation where non-Black individuals use memes and gifs featuring Black people and even emojis with dark skin; a 21st century version of Black minstrelsy, which was prevalent in the 19th and 20th centuries
 
+a form of appropriation where non-Black individuals use memes and gifs featuring Black people and even emojis with dark skin; a 21st century version of Black minstrelsy, which was prevalent in the 19th and 20th centuries
 
 ## Issues
 
@@ -18,14 +18,15 @@ Digital Blackface is one of many ways of dehumanising Black individuals into exa
 
 Digital Blackface is also an issue of representation and culture appropriation: memes and gifs are often used in spaces where no real Black people are present, which presents them as a prop to be used in all-white spaces. Black culture is stolen from Black people and commodified by non-Black people.
 
-
 ## Examples
-- Online personas: It can go further than appropration. Falsified personas are easy to spot as they almost always use terms like "as a black woman..." [sic] and resort to incorrect and illegitimate use of African American Vernacular English (AAVE).[1](https://www.buzzfeednews.com/article/ryanhatesthis/your-slip-is-showing-4chan-trolls-operation-lollipop) 
 
-"On Twitter lie countless handles featuring a Black person’s image, run by users who are most assuredly not Black. These accounts, which often include a “ghetto” name — the formula prefix “La+” is a favored trope — are riddled with poor attempts at Black vernacular, and feature stereotypes from the minstrel stage." [2](https://www.theawl.com/2014/08/memes-and-misogynoir/)
+- Online personas: It can go further than appropration. Falsified personas are easy to spot as they almost always use terms like "as a black woman..." [sic] and resort to incorrect and illegitimate use of African American Vernacular English (AAVE).[1](https://www.buzzfeednews.com/article/ryanhatesthis/your-slip-is-showing-4chan-trolls-operation-lollipop)
+
+  "On Twitter lie countless handles featuring a Black person’s image, run by users who are most assuredly not Black. These accounts, which often include a “ghetto” name — the formula prefix “La+” is a favored trope — are riddled with poor attempts at Black vernacular, and feature stereotypes from the minstrel stage." [2](https://www.theawl.com/2014/08/memes-and-misogynoir/)
 
 - Gifs
-"For while reaction GIFs can and do every feeling under the sun, white and nonblack users seem to especially prefer GIFs with black people when it comes to emitting their most exaggerated emotions. Extreme joy, annoyance, anger and occasions for drama and gossip are a magnet for images of black people, especially black femmes." [1](https://www.teenvogue.com/story/digital-blackface-reaction-gifs)
+
+  "For while reaction GIFs can and do every feeling under the sun, white and nonblack users seem to especially prefer GIFs with black people when it comes to emitting their most exaggerated emotions. Extreme joy, annoyance, anger and occasions for drama and gossip are a magnet for images of black people, especially black femmes." [1](https://www.teenvogue.com/story/digital-blackface-reaction-gifs)
 
 - Emojis (using a darker-than-your-own skin-tone, especially when you are white)[1](https://www.npr.org/sections/codeswitch/2018/03/21/425573955/white-skin-black-emojis)[2](https://techcrunch.com/2017/10/01/thoughts-on-white-people-using-dark-skinned-emoji/)
 

--- a/11ty/definitions/dude.md
+++ b/11ty/definitions/dude.md
@@ -5,16 +5,18 @@ defined: true
 flag:
   level: avoid
 alt_words:
-  - wow
-  - oh my word
-  - yikes
-  - y'all
-  - friend
-  - mate
-  - fam
-  - folks
-  - pal*
-  - buddy*
+  expression of astonishment:
+    - wow
+    - oh my word
+    - yikes
+  noun:
+    - y'all
+    - friend
+    - mate
+    - fam
+    - folks
+    - pal*
+    - buddy*
 reading:
   - text: Etymonline entry
     href: https://www.etymonline.com/word/dude


### PR DESCRIPTION
## What

In Markdown word definitions, the frontmatter contains an `alt_words` key, which only supports arrays. This PR is a first-pass at expanding this to support categories (as a hash/object). #170 outlines an "advanced level description", but I wasn't totally sure I understood the outline, so I opted for the simpler solution for me.

## Usage

I changed the entry for `dude` as a start. We can incrementally edit the other entries as needed.

Before, we only supported this format:

```yaml
alt_words:
  - wow
  - oh my word
  - yikes
  - y'all
  - friend
  - mate
  - fam
  - folks
  - pal*
  - buddy*
```

Now, we also support categories:

```yaml
alt_words:
  expression of astonishment:
    - wow
    - oh my word
    - yikes
  noun:
    - y'all
    - friend
    - mate
    - fam
    - folks
    - pal*
    - buddy*
```

**I'm happy to change the category names to fit #170.** I pulled these categories from the content, and I also wanted to test that spaces in category names translated to the right HTML `id` :grin:

## Technical details

When rendering `alt_words`, we branch on whether the value is an object (`{}`) or an array (`[]`). If it's an array, then like before, we render the alternatives as a semi-colon-separated list. If it's an object, we take the keys (category name) and the values (either an array of alternatives or another category object), then render the category names while redoing these steps again on the value.

## What does it look like?

![Alternatives for the word dude with the implemented changes](https://user-images.githubusercontent.com/167743/84194328-b55c0100-aa51-11ea-9002-1c490d637cd9.png)

**Image description:** The alternative words for "dude" are separated into two categories: "expression of astonishment" and "noun". The categories are bolded, and underneath each category are its associated alternative words in a list separated by semi-colons.

## Caveats

1. I couldn't tell if there was a process for claiming issues or starting discussions about which solution to pursue. In any case, I am not attached to any of this code/design, and I'm happy to change anything, or throw all this away.
1. This only really supports one level of categories; I didn't style for multiple category levels. I think multi-level probably deserves a bigger conversation + more thoughtful styling.
1. I'm not a full-time screen reader user so I did some guesses on the appropriate labeling strategy for the lists and tested it out in practice (with VO). But, I can't say for sure it's the right solution.
1. I did not update documentation. I wanted to get an idea of what y'all are looking for first.