### PR TITLE
fix: also run Actions CI on Pull Request events

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: Node CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   test:


### PR DESCRIPTION
Currently CI only runs on `push`. This adds runs for `pull_request`. There are differences between the two ([push](https://help.github.com/en/actions/reference/events-that-trigger-workflows#push-event-push), [pull_request](https://help.github.com/en/actions/reference/events-that-trigger-workflows#pull-request-event-pull_request)) though the bounds of where they intersect aren't clear to me fully.

This is _potentially_ a solution for the CI not running on all PRs. 