### PR TITLE
Fixes broken link to definition of pansexual

### DIFF
--- a/11ty/definitions/biromantic.md
+++ b/11ty/definitions/biromantic.md
@@ -16,6 +16,6 @@ of, relating to, or characterised by being romantically attracted to more than o
 
 ## Note
 
-Biromantic does not imply any particular kind of sexual attraction, or sexual attraction at all. A biromantic person may be asexual, homosexual, heterosexual, [bisexual](/definitions/bisexual), [pansexual](/definitions/pan-sexual), etc.
+Biromantic does not imply any particular kind of sexual attraction, or sexual attraction at all. A biromantic person may be asexual, homosexual, heterosexual, [bisexual](/definitions/bisexual), [pansexual](/definitions/pansexual), etc.
 
 Biromantic does not preclude romantic attraction to [non-binary](/definitions/non-binary) or [transgender](/definitions/transgender) people.

--- a/11ty/definitions/pansexual.md
+++ b/11ty/definitions/pansexual.md
@@ -1,6 +1,6 @@
 ---
 title: Pansexual
-slug: pan-sexual
+slug: pansexual
 speech: adj
 defined: true
 reading:

--- a/_util/_mocks/testCollection.json
+++ b/_util/_mocks/testCollection.json
@@ -1,40 +1,130 @@
 [
-  { "data": { "slug": "ok-hand", "title": "👌 [ok-hand]" } },
-  { "data": { "slug": "ableism", "title": "Ableism" } },
-  { "data": { "slug": "barbaric", "title": "Barbaric" } },
-  { "data": { "slug": "biromantic", "title": "Biromantic" } },
-  { "data": { "slug": "bisexual", "title": "Bisexual" } },
-  { "data": { "slug": "cisgender", "title": "Cisgender" } },
-  { "data": { "slug": "crazy", "title": "crazy" } },
+  {
+    "data": {
+      "slug": "ok-hand",
+      "title": "👌 [ok-hand]"
+    }
+  },
+  {
+    "data": {
+      "slug": "ableism",
+      "title": "Ableism"
+    }
+  },
+  {
+    "data": {
+      "slug": "barbaric",
+      "title": "Barbaric"
+    }
+  },
+  {
+    "data": {
+      "slug": "biromantic",
+      "title": "Biromantic"
+    }
+  },
+  {
+    "data": {
+      "slug": "bisexual",
+      "title": "Bisexual"
+    }
+  },
+  {
+    "data": {
+      "slug": "cisgender",
+      "title": "Cisgender"
+    }
+  },
+  {
+    "data": {
+      "slug": "crazy",
+      "title": "crazy"
+    }
+  },
   {
     "data": {
       "slug": "english-as-second-language",
       "title": "English as Second Language (ESL)"
     }
   },
-  { "data": { "slug": "fatphobia", "title": "Fatphobia" } },
-  { "data": { "slug": "gaslighting", "title": "Gaslighting" } },
-  { "data": { "slug": "minorities", "title": "minorities" } },
-  { "data": { "slug": "minoritised", "title": "minoritised" } },
-  { "data": { "slug": "non-binary", "title": "Non-binary" } },
+  {
+    "data": {
+      "slug": "fatphobia",
+      "title": "Fatphobia"
+    }
+  },
+  {
+    "data": {
+      "slug": "gaslighting",
+      "title": "Gaslighting"
+    }
+  },
+  {
+    "data": {
+      "slug": "minorities",
+      "title": "minorities"
+    }
+  },
+  {
+    "data": {
+      "slug": "minoritised",
+      "title": "minoritised"
+    }
+  },
+  {
+    "data": {
+      "slug": "non-binary",
+      "title": "Non-binary"
+    }
+  },
   {
     "data": {
       "slug": "obsessive-compulsive-disorder",
       "title": "Obsessive Compulsive Disorder (OCD)"
     }
   },
-  { "data": { "slug": "pan-sexual", "title": "Pansexual" } },
+  {
+    "data": {
+      "slug": "pansexual",
+      "title": "Pansexual"
+    }
+  },
   {
     "data": {
       "slug": "performative-allyship",
       "title": "performative allyship"
     }
   },
-  { "data": { "slug": "polyamory", "title": "Polyamory" } },
-  { "data": { "slug": "spaz", "title": "Spaz" } },
-  { "data": { "slug": "transgender", "title": "Transgender" } },
-  { "data": { "slug": "unreal", "title": "unreal" } },
-  { "data": { "slug": "white-fragility", "title": "White Fragility" } },
+  {
+    "data": {
+      "slug": "polyamory",
+      "title": "Polyamory"
+    }
+  },
+  {
+    "data": {
+      "slug": "spaz",
+      "title": "Spaz"
+    }
+  },
+  {
+    "data": {
+      "slug": "transgender",
+      "title": "Transgender"
+    }
+  },
+  {
+    "data": {
+      "slug": "unreal",
+      "title": "unreal"
+    }
+  },
+  {
+    "data": {
+      "slug": "white-fragility",
+      "title": "White Fragility"
+    }
+  },
   {
     "data": {
       "slug": "women-and-people-of-colour",


### PR DESCRIPTION
- Fixes broken link to definition of `pansexual` from homepage and from `bisexual` definition page (see [issue #222](https://github.com/selfdefined/web-app/issues/222))