### PR TITLE
➕ Add plausibility check as alt word for sanity check

### DIFF
--- a/11ty/definitions/sanity-check.md
+++ b/11ty/definitions/sanity-check.md
@@ -17,6 +17,7 @@ alt_words:
   - smoke test
   - temperature check
   - soundness check
+  - plausibility check
   - spot check
   - gut check
 reading:


### PR DESCRIPTION
I found _plausibility check_ to be more fitting as substitute for _sanity check_ in some context, thus adding it to the list of alternative words.