### PR TITLE
➕ Add "basic" as alternative for "dumb"

### DIFF
--- a/11ty/definitions/dumb.md
+++ b/11ty/definitions/dumb.md
@@ -7,6 +7,7 @@ flag:
 defined: true
 speech: adjective
 alt_words:
+  - basic
   - incomprehensible
   - nonsensical
   - redundant


### PR DESCRIPTION
I encountered the following text fragment: "... write a dumb stub version ...", where "basic" seems like an appropriate substitute for "dumb".