### PR TITLE
Fix slug for sane

### DIFF
--- a/11ty/definitions/sane.md
+++ b/11ty/definitions/sane.md
@@ -1,6 +1,6 @@
 ---
 title: sane
-slug: sanity-check
+slug: sane
 flag:
   text: 'Medical appropriation'
   level: avoid


### PR DESCRIPTION
Currently the word sane links to the "sanity-check" page making it difficult to view the definition for "sane"