### PR TITLE
Fix mis-configured grid for <ul>s inside definitions

### DIFF
--- a/assets/css/structures/_definition-content.scss
+++ b/assets/css/structures/_definition-content.scss
@@ -35,6 +35,10 @@
       grid-column: 1 / -1;
       line-height: 1.4;
     }
+    
+    & > ul {
+      grid-column: 1 / -1;
+    }
 
     & h2 {
       flex: 0 1 auto;


### PR DESCRIPTION
## Summary
This PR was made to fix the following UI issue found [here](https://www.selfdefined.app/definitions/southeast-asian/)

### Before
<img width="420" alt="Screen Shot 2020-09-04 at 4 50 55 PM" src="https://user-images.githubusercontent.com/4626157/92291824-3a2ead80-eecf-11ea-85c7-746afe8ef152.png">

### After
<img width="810" alt="Screen Shot 2020-09-04 at 4 50 44 PM" src="https://user-images.githubusercontent.com/4626157/92291826-3bf87100-eecf-11ea-8dec-67af2169815a.png">


## Details
It looks like only paragraph level list items have the `grid-column` configuration css included. This adds the `grid-column` attribute to any `ul` item that's a direct child of the definition content. 

*note*: Not sure if this app might benefit if all "block" items should receive this `grid-column` treatment. But for now this change should fix the visual blip.