### PR TITLE
Adjusts Southeast Asian countries list

### DIFF
--- a/11ty/definitions/southeast-asian.md
+++ b/11ty/definitions/southeast-asian.md
@@ -8,8 +8,25 @@ skip_in_table_of_content: true
 ---
 umbrella term for people of Southeast Asian descent. South Asian countries include two sub-regions:
 
-- **Mainland Southeast Asia:** Cambodia, Laos, Myanmar, Peninsular Malaysia, Thailand and Vietnam.
-- **Maritime Southeast Asia:** Andaman and Nicobar Islands (India), Ashmore and Cartier Islands (Australia), Brunei, Christmas Island (Australia), the Cocos (Keeling) Islands (Australia), East Malaysia, East Timor, Indonesia (except Western New Guinea, which is considered a part of the Australian continent), the Philippines and Singapore.
+### Mainland Southeast Asia:
+- Cambodia
+- Laos
+- Myanmar
+- Peninsular Malaysia
+- Thailand
+- Vietnam
+
+### Maritime Southeast Asia:
+- Andaman and Nicobar Islands (India)
+- Ashmore and Cartier Islands (Australia)
+- Brunei
+- Christmas Island (Australia)
+- the Cocos (Keeling) Islands (Australia)
+- East Malaysia
+- East Timor
+- Indonesia (except Western New Guinea, which is considered a part of the Australian continent)
+- the Philippines
+- Singapore
 
 ## Considerations
 

--- a/11ty/definitions/southeast-asian.md
+++ b/11ty/definitions/southeast-asian.md
@@ -8,7 +8,8 @@ skip_in_table_of_content: true
 ---
 umbrella term for people of Southeast Asian descent. South Asian countries include two sub-regions:
 
-### Mainland Southeast Asia:
+### Mainland Southeast Asia
+
 - Cambodia
 - Laos
 - Myanmar
@@ -16,7 +17,8 @@ umbrella term for people of Southeast Asian descent. South Asian countries inclu
 - Thailand
 - Vietnam
 
-### Maritime Southeast Asia:
+### Maritime Southeast Asia
+
 - Andaman and Nicobar Islands (India)
 - Ashmore and Cartier Islands (Australia)
 - Brunei

--- a/assets/css/structures/_definition-content.scss
+++ b/assets/css/structures/_definition-content.scss
@@ -63,6 +63,11 @@
       // padding-left: 1rem;
       grid-column: 2;
     }
+
+    & h3 ~ ul {
+      border-bottom: 0.1rem solid lightgrey;
+      padding-bottom: 1rem;
+    }
   }
 
   &__speech {


### PR DESCRIPTION
This PR will close #271 

This enhances the layout of the countries listed in the definition for Southeast Asian by using two columns.

Screenshots before and after:
<img width="1552" alt="Screen Shot 2020-09-07 at 6 49 43 PM" src="https://user-images.githubusercontent.com/31839316/92422519-efb16900-f13a-11ea-881d-2f8d1c9f2594.png">
<img width="1552" alt="Screen Shot 2020-09-07 at 7 04 01 PM" src="https://user-images.githubusercontent.com/31839316/92423106-0658bf80-f13d-11ea-89d9-6d7b10c77553.png">

First, I changed the markdown to have better ease of reading:

> * Adds h3 headings to Mainland / Maritime sub-regions
> * Each country is now a list item element

Then, I added new CSS rules.
```css
& h3 ~ ul {
  border-bottom: 0.1rem solid lightgrey;
  padding-bottom: 1rem;
}
```

Future definitions can use this new layout by following this Markdown example:
```
### Sandwich Condiments

- Mayonaise
- Mustard

### Pasta Sauces

- Marinara
- Pesto
```

Or this HTML example:
```
<h3>Sandwich Condiments</h3>

<ul>
  <li>Mayonaise</li>
  <li>Mustard</li>
</ul>

<h3>Pasta Sauces</h3>

<ul>
  <li>Marinara</li>
  <li>Pesto</li>
<ul>
```