### PR TITLE
Fixing three links in code of conduct

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -73,11 +73,11 @@ Community leaders will follow these Community Impact Guidelines in determining t
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.0,
-available at <https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.>
+available at <https://www.contributor-covenant.org/version/2/0/code_of_conduct.html>.
 
 Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
 
 [homepage]: https://www.contributor-covenant.org
 
 For answers to common questions about this code of conduct, see the FAQ at
-<https://www.contributor-covenant.org/faq.> Translations are available at <https://www.contributor-covenant.org/translations.>
+<https://www.contributor-covenant.org/faq>. Translations are available at <https://www.contributor-covenant.org/translations>.


### PR DESCRIPTION
Each inline link had the sentence full-stop/period within the URL markdown, stopping the links from opening. Move full-stops to the end of the sentence, outside of the link markdown.