### PR TITLE
Replace expired Slack link in Readme

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,7 @@ We have created some examples that you can use as the baseline for your work. Ta
 
 If you've already tried reading through our [documentation](https://www.selfdefined.app/documentation/) and are stuck, we're here to help and ask your questions:
 
-- Join our [Slack community](https://join.slack.com/t/selfdefined/shared_invite/zt-fczgm8b6-8ZZgHvLutNDXo~NjwaL7Iw).
+- Join our [Slack community](https://selfdefined.slack.com/join/shared_invite/zt-i0ctid84-a2t6AM1QIqS0xdW71PzYPw#/).
 - Reach out to [@SelfDefinedApp](https://www.twitter.com/selfdefinedapp) on Twitter.
 - File an [issue](https://github.com/tatianamac/selfdefined/issues/new) if you think our docs are missing some information that might be helpful.
 - Contact <selfdefined@tatianamac.com>.


### PR DESCRIPTION
The current invite link to join the Slack community is expired. Therefore, I've replaced it with the latest link provided to users via Twitter.