### PR TITLE
Style `ul`s like `p`s when they're direct content

### DIFF
--- a/assets/css/structures/_definition-content.scss
+++ b/assets/css/structures/_definition-content.scss
@@ -29,7 +29,8 @@
       }
     }
 
-    & > p {
+    & > p,
+    & > ul {
       font-family: $sans-serif;
       font-size: 1.5rem;
       grid-column: 1 / -1;


### PR DESCRIPTION
Without this change, `ul`s get compressed to a single grid column if they're direct children of `.definition-content__content`.

# Before

![image](https://user-images.githubusercontent.com/1027364/95352536-3c16d280-08ba-11eb-8ddf-fd5c9f4d072e.png)

# After

![image](https://user-images.githubusercontent.com/1027364/95352683-5f418200-08ba-11eb-8470-d54e1384b187.png)
