### PR TITLE
Adds Discord redirect, fallback page

### DIFF
--- a/11ty/discord/index.md
+++ b/11ty/discord/index.md
@@ -1,0 +1,5 @@
+---
+title: Invites Closed
+---
+
+Invitations to the Discord server are currently closed. Please keep an eye on our [Twitter account](https://twitter.com/SelfDefinedApp) for updates!

--- a/11ty/discord/index.md
+++ b/11ty/discord/index.md
@@ -1,5 +1,0 @@
----
-title: Invites Closed
----
-
-Invitations to the Discord server are currently closed. Please keep an eye on our [Twitter account](https://twitter.com/SelfDefinedApp) for updates!

--- a/11ty/discord/index.njk
+++ b/11ty/discord/index.njk
@@ -1,0 +1,11 @@
+{% extends 'layouts/base.njk' %}
+{% set pageType = 'Page' %}
+{% set titleWithPath = 'Invitations Closed « ' %}
+{% block content %}
+  <div class="article-content">
+    {% include 'components/sub-page-header.njk' %}
+    <main class="page">
+      <p>Invitations to the Discord server are currently closed. Please keep an eye on our <a href="https://twitter.com/SelfDefinedApp">Twitter account</a> for updates!</p>
+    </main>
+	</div>
+{% endblock %}

--- a/11ty/discord/index.njk
+++ b/11ty/discord/index.njk
@@ -5,6 +5,7 @@
   <div class="article-content">
     {% include 'components/sub-page-header.njk' %}
     <main class="page">
+      <h1>Discord Invitations</h1>
       <p>Invitations to the Discord server are currently closed. Please keep an eye on our <a href="https://twitter.com/SelfDefinedApp">Twitter account</a> for updates!</p>
     </main>
 	</div>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,7 @@ We have created some examples that you can use as the baseline for your work. Ta
 
 If you've already tried reading through our [documentation](https://www.selfdefined.app/documentation/) and are stuck, we're here to help and ask your questions:
 
-- Join our [Discord community](https://discord.gg/c4XtX4F2tK).
+- Join our [Discord community](https://selfdefined.app/discord).
 - Reach out to [@SelfDefinedApp](https://www.twitter.com/selfdefinedapp) on Twitter.
 - File an [issue](https://github.com/tatianamac/selfdefined/issues/new) if you think our docs are missing some information that might be helpful.
 - Contact <selfdefined@tatianamac.com>.

--- a/netlify.toml
+++ b/netlify.toml
@@ -18,8 +18,8 @@
   force = true
   headers = {X-From = "Netlify"}
 
-[[redirects]]
-  from = "/discord"
-  to = "https://discord.com/invite/c4XtX4F2tK"
-  status = 301
-  force = true
+# [[redirects]]
+#   from = "/discord"
+#   to = "https://discord.com/invite/c4XtX4F2tK"
+#   status = 301
+#   force = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -18,8 +18,8 @@
   force = true
   headers = {X-From = "Netlify"}
 
-# [[redirects]]
-#   from = "/discord"
-#   to = "https://discord.com/invite/c4XtX4F2tK"
-#   status = 301
-#   force = true
+[[redirects]]
+  from = "/discord"
+  to = "https://discord.com/invite/c4XtX4F2tK"
+  status = 301
+  force = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -17,3 +17,9 @@
   status = 301
   force = true
   headers = {X-From = "Netlify"}
+
+[[redirects]]
+  from = "/discord"
+  to = "https://discord.com/invite/c4XtX4F2tK"
+  status = 301
+  force = true


### PR DESCRIPTION
This PR sets up a redirect at `selfdefined.app/discord`, which we can use to hot-swap invite links to "open" and "close" the server. To "close" the server, we comment out the redirect, which will cause the fallback page (`11ty/discord/index.md`) to be served. To "open" the server, we uncomment the redirect and commit a fresh invitation link generated by Discord.

_This is a work in progress; since this involves Netlify, I have to push it up and open a PR to test._