### PR TITLE
Add Spanish translation for "third-world-country"

### DIFF
--- a/11ty/es/definiciones/pais-del-tercer-mundo.md
+++ b/11ty/es/definiciones/pais-del-tercer-mundo.md
@@ -1,0 +1,28 @@
+---
+title: país del tercer mundo
+slug: pais-del-tercer-mundo
+defined: true
+speech: noun
+flag:
+  level: avoid
+  warning: lenguaje colonialista
+
+---
+
+describe un país que no se alinea totalmente a la ideología occidental o la imagen occidental de la sociedad. _(También comunes son los términos «tercermundista», «primer mundo», «naciones subdesarrolladas/en desarrollo/desarrolladas», etc.)._
+
+## Historia
+
+La terminología de «tres mundos» surgió originalmente durante la guerra fría para definir a los países que estaban alineados con la Organización del Tratado del Atlántico Norte (OTAN) («primer mundo»), alineados con el Pacto de Varsovia («segundo mundo»), o no alineados («tercer mundo»). Debido a que muchos países del tercer mundo eran pobres económicamente, se hizo común referise a países pobres como del tercer mundo.
+
+## Problemas
+
+En primer lugar, el término es arcaico y se refiere a una visión de /_la OTAN vs. les comunistas_/ que ya no es relevante. En segundo lugar, y más importante, presupone una jerarquía entre países, clasificados según los ideales occidentales de homogeneidad. La ideología occidental es una forma bastante estrecha de percibir la cuestiones socieconómicas globales. Según la palabras de [Zeeshan Aleem](_https://www.mic.com/articles/107686/why-you-shouldn-t-call-poor-nations-third-world-countries_): «La socialdemocracia en Escandinavia, la teocracia pagada con petróleo en Arabia Saudita y el partido único y la economía en parte planificada, en parte de libre mercado en China son todos diferentes modelos para generar y mantener prosperidad».
+
+## Impacto
+
+Este lenguaje se ha forjado en la visión del mundo occidental o ameri/anglocéntrica. Trata a cada país, región o cultura que no haya seguido o siga el ideal occidental de «progreso» o «desarrollo», y otros, como menor. Carece de contexto y es deshumanizante para esas personas.
+
+## Consejos de uso
+
+Sé más específique o contextual. Si queremos decir «países con altas tasas de mortalidad infantil», o «países que experimentan un brote de VIH/SIDA», probablemente debamos decirlo de esa manera. Es mucho más claro ser específique. Aún más, considera el contexto de lo que estamos usando para sustituir la frase: ¿Estamos aún imponiendo valores occidentales/colonialistas a nuestro lenguaje?


### PR DESCRIPTION
I added the translation inside /es/definitions instead of definitions/es as discussed in the Discord channel.
I didn't add a link from the English definition because the styling in this new location seems to be broken at the moment.