### PR TITLE
Adds word albino

### DIFF
--- a/11ty/definitions/albino.md
+++ b/11ty/definitions/albino.md
@@ -1,0 +1,12 @@
+---
+title: Albino
+slug: albino
+speech: adjective
+flag:
+  level: avoid
+  text: ableist slur
+defined: false
+reading:
+- text: 'National Organization for Albinism and Hypopigmentation: What Do You Call Me?'
+  href: https://www.albinism.org/information-bulletin-what-do-you-call-me
+---


### PR DESCRIPTION
Addresses issue #421 

Added the word "albino" to the definitions list. As I don't have albinism, I didn't feel comfortable attempting to define the term. Next steps would include filling in the definition with input from folks affected by the term.

Please see the issue for videos outlining reasons for inclusion in the dictionary as well as the reading section included in `albino.md`'s frontmatter.