### PR TITLE
Adds definition for "short bus" per #433

### DIFF
--- a/11ty/_includes/layouts/base.njk
+++ b/11ty/_includes/layouts/base.njk
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="preconnect" href="https://use.typekit.net/" crossorigin>
+    <link rel="preconnect" href="https://use.typekit.net/">
     <link rel="dns-prefetch" href="https://use.typekit.net/">
-    <link rel="preconnect" href="https://p.typekit.net/" crossorigin>
+    <link rel="preconnect" href="https://p.typekit.net/">
     <link rel="dns-prefetch" href="https://p.typekit.net/">
     {# Use title with path, or append a space to the page title to avoid collpasing with the meta title #}
     {% set pageTitle = titleWithPath or title + ' ' or '' %}

--- a/11ty/definitions/short-bus.md
+++ b/11ty/definitions/short-bus.md
@@ -16,7 +16,11 @@ a [Type A or B school bus](https://en.wikipedia.org/wiki/School_bus#Types), whic
 
 ## Issues
 
-There are four school bus types ranging from A to D, with the Type C school bus being the conventional vehicle used to transport large numbers of students. The term "short bus" upholds the perception in which students without an I/DD ride exclusively on Type C buses meant for "normal" students, while their "abnormal" peers are relegated to smaller Type A or B buses. This perception ignores the reality that Type A and B school buses may be used to transport small numbers of students&mdash;often in remote or rural communities&mdash;directly to school or to a hub to transfer to a larger bus.
+## Issues
+The term "short bus" upholds several **false** and **[ableist](/definitions/ableism)** ideas:
+- Students without I/DD ride exclusively on Type C buses, whereas students with I/DD ride exclusively on Type A and B buses. Type C buses are more abundant, used by nondisabled students, and thus seen as "normal." Type A and B buses are less common, and often used by disabled students, and thus seen as "abnormal," making it the target of jokes (at the expense of disabled students). This idea reiterates disabled as "abnormal" and nondisabled as "normal."
+- Type A and B school buses are only used for disabled students, when in reality, they may be used to transport small numbers of students&mdash;often in remote or rural communities&mdash;directly to school or to a hub to transfer to a larger bus.
+- Mobility aids and accessibility infrastructure, which tend to be [undersupported and underfunded](https://www.nydailynews.com/opinion/ny-oped-infrastructure-raw-deal-disabled-20210805-mgmhsqiy4rdtvc3jsgqhvilf5u-story.html), are worthy of mockery. This type of codified insult is one way in which infrastructural issues are reinforced and perpetuated by cultural norms.
 
 The term upholds an ableist sense of normalcy, and furthers the harmful and exclusionary practices that segregate those with an I/DD from the rest of society while depriving them of their dignity.
 

--- a/11ty/definitions/short-bus.md
+++ b/11ty/definitions/short-bus.md
@@ -2,7 +2,7 @@
 title: short bus
 slug: short-bus
 defined: true
-excerpt: A derogatory and ableist term synonymous with the r-word. It refers to a Type A or B school bus, which is smaller than the conventional Type C bus. The term is commonly associated with and used to insult those with intellectual or developmental disabilities, or mock others at their expense.
+avoid: commonly refers to a smaller school bus; colloquially: a derogatory term insult against or at the expense of people with intellectual or developmental disabilities (I/DD).
 speech: noun
 flag:
   level: avoid

--- a/11ty/definitions/short-bus.md
+++ b/11ty/definitions/short-bus.md
@@ -9,7 +9,10 @@ flag:
   text: ableist slur
 ---
 
-"Short bus" is a derogatory and ableist term for a [Type A or B school bus](https://en.wikipedia.org/wiki/School_bus#Types). While these school bus types are used to transport smaller groups of students to school or related activities, they may also be used to transport students with intellectual and/or developmental disabilities (I/DD). The term is a derogatory shorthand for [the r-word](/r-word/).
+a [Type A or B school bus](https://en.wikipedia.org/wiki/School_bus#Types), which tends to be smaller than a conventional school bus (Type C); colloquially: a derogatory term used against people with intellectual and/or developmental disabilities (I/DD). 
+
+## Related Terms
+[r-word](/r-word/)
 
 ## Issues
 

--- a/11ty/definitions/short-bus.md
+++ b/11ty/definitions/short-bus.md
@@ -26,7 +26,7 @@ The term upholds an ableist sense of normalcy, and furthers the harmful and excl
 
 ## Impact
 
-As is the case with any ableist term, "short bus" is a derogatory synonym for the the r-word that should be avoided. It is dehumanizing slang used by children and adults alike to directly insult disabled people, or mock those without an I/DD for perceived low intelligence or capability at the expense of those who have an I/DD.
+As is the case with any ableist term, "short bus" is a derogatory slur, which is often used synonymously for the the r-word. Regardless of intent, awareness or target of the insult, using this term dehumanises disabled people by mocking perceived low intelligence or capability.
 
 When we use ableist language, we are creating spaces in which we willingly harm those experiencing physical, mental, or psychological disabilities, regardless of our intent.
 

--- a/11ty/definitions/short-bus.md
+++ b/11ty/definitions/short-bus.md
@@ -32,6 +32,18 @@ When we use ableist language, we are creating spaces in which we willingly harm 
 
 ## Alt Words
 
-There is no scenario in which the term "short bus" can be used constructively, unless the intent is to discuss the term itself in an effort to remove it from common usage. In all other situations in which you are describing someone's actions or output, use descriptive language rather than insulting someone at the expense of those with an I/DD.
+## Usage/Alt Words
+
+When referring to the smaller bus, use Type C, which is more specific and accurate.
+
+When using it as an insult, it cannot be used constructively. Usage should be reserved to discuss the term itself in an effort to remove it from common usage and reduce its ongoing harm.
+
+In all other situations, use descriptive language to describe the person's output or actions: For example, if someone writes a paper that is factually inaccurate or otherwise lacking in substance, offer a constructive criticism of paper's contents rather than attempt to humiliate them with ableist language that perpetuates harm.
+
+Some examples of phrases that could replace common self-deprecating usages:
+- "What a brain fart."
+- "Wow, that was so spacey of me."
+- "I can't believe I did that. I must be tired."
+- "I had a lapse in judgment."
 
 For example, if someone writes a paper that is factually inaccurate or otherwise lacking in substance, offer a constructive criticism of paper's contents rather than attempt to humiliate them with ableist language that perpetuates harm.

--- a/11ty/definitions/short-bus.md
+++ b/11ty/definitions/short-bus.md
@@ -1,5 +1,5 @@
 ---
-title: Short bus
+title: short bus
 slug: short-bus
 defined: true
 excerpt: A derogatory and ableist term synonymous with the r-word. It refers to a Type A or B school bus, which is smaller than the conventional Type C bus. The term is commonly associated with and used to insult those with intellectual or developmental disabilities, or mock others at their expense.

--- a/11ty/definitions/short-bus.md
+++ b/11ty/definitions/short-bus.md
@@ -1,0 +1,30 @@
+---
+title: Short bus
+slug: short-bus
+defined: true
+excerpt:
+speech: noun
+flag:
+  level: avoid
+  text: ableist slur
+---
+
+"Short bus" is an ableist slang term for a [Type A or B school bus](https://en.wikipedia.org/wiki/School_bus#Types). While these school bus types are used to transport smaller groups of students to school or related activities, they may also be used to transport students with intellectual and/or developmental disabilities (I/DD). The term is a derogatory shorthand for [the r-word](/r-word/).
+
+## Issues
+
+There are four school bus types ranging from A to D, with the Type C school bus being the conventional vehicle used to transport large numbers of students. The term "short bus" upholds the perception in which students without an I/DD ride exclusively on Type C buses meant for "normal" students, while their "abnormal" peers are relegated to smaller Type A or B buses. This perception ignores the reality that Type A and B school buses may be used to transport small numbers of students&mdash;often in remote or rural communities&mdash;directly to school or to a hub to transfer to a larger bus.
+
+The term upholds an ableist sense of normalcy, and furthers the harmful and exclusionary practices that segregate those with an I/DD from the rest of society while depriving them of their dignity.
+
+## Impact
+
+As is the case with any ableist term, "short bus" is a derogatory synonym for the the r-word that should be avoided. It is dehumanizing slang used by children and adults alike to directly insult disabled people, or mock those without an I/DD for perceived low intelligence or capability at the expense of those who have an I/DD.
+
+When we use ableist language, we are creating spaces in which we willingly harm those experiencing physical, mental, or psychological disabilities, regardless of our intent.
+
+## Alt Words
+
+There is no scenario in which the term "short bus" can be used constructively, unless the intent is to discuss the term itself in an effort to remove it from common usage. In all other situations in which you are describing someone's actions or output, use descriptive language rather than insulting someone at the expense of those with an I/DD.
+
+For example, if someone writes a paper that is factually inaccurate or otherwise lacking in substance, offer a constructive criticism of paper's contents rather than attempt to humiliate them with ableist language that perpetuates harm.

--- a/11ty/definitions/short-bus.md
+++ b/11ty/definitions/short-bus.md
@@ -2,14 +2,14 @@
 title: Short bus
 slug: short-bus
 defined: true
-excerpt:
+excerpt: A derogatory and ableist term synonymous with the r-word. It refers to a Type A or B school bus, which is smaller than the conventional Type C bus. The term is commonly associated with and used to insult those with intellectual or developmental disabilities, or mock others at their expense.
 speech: noun
 flag:
   level: avoid
   text: ableist slur
 ---
 
-"Short bus" is an ableist slang term for a [Type A or B school bus](https://en.wikipedia.org/wiki/School_bus#Types). While these school bus types are used to transport smaller groups of students to school or related activities, they may also be used to transport students with intellectual and/or developmental disabilities (I/DD). The term is a derogatory shorthand for [the r-word](/r-word/).
+"Short bus" is a derogatory and ableist term for a [Type A or B school bus](https://en.wikipedia.org/wiki/School_bus#Types). While these school bus types are used to transport smaller groups of students to school or related activities, they may also be used to transport students with intellectual and/or developmental disabilities (I/DD). The term is a derogatory shorthand for [the r-word](/r-word/).
 
 ## Issues
 


### PR DESCRIPTION
Apologies for the long wait on the PR. It adds the definition for the ableist term "short bus" as proposed in issue #433. It also opportunistically removes an unnecessary `crossorigin` attribute on the `rel=preload` `<link>` elements in the header.