### PR TITLE
Fix links in "Reading" section of add-adhd.md

### DIFF
--- a/11ty/definitions/add-adhd.md
+++ b/11ty/definitions/add-adhd.md
@@ -5,13 +5,13 @@ defined: true
 speech: noun
 reading:
   - text: 'What Is ADHD? Meaning, Symptoms & Tests'
-    href: <https://www.additudemag.com/what-is-adhd-symptoms-causes-treatments/>
+    href: https://www.additudemag.com/what-is-adhd-symptoms-causes-treatments/
   - text: 'No Time To Confront Racism In Neurodiversity'
-    href: <https://blackgirllostkeys.com/adhd/no-time-to-confront-racism-in-neurodiversity/>
+    href: https://blackgirllostkeys.com/adhd/no-time-to-confront-racism-in-neurodiversity/
   - text: DSM-5 ADHD Diagnosis
-    href: <https://www.cdc.gov/ncbddd/adhd/diagnosis.html>
+    href: https://www.cdc.gov/ncbddd/adhd/diagnosis.html
   - text: ICD-11 ADHD Entry
-    href: <https://icd.who.int/browse11/l-m/en#/http%3a%2f%2fid.who.int%2ficd%2fentity%2f821852937>
+    href: https://icd.who.int/browse11/l-m/en#/http%3a%2f%2fid.who.int%2ficd%2fentity%2f821852937
 ---
 
 ## Overview


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
At the moment, links are broken at the bottom of the <https://www.selfdefined.app/definitions/add-adhd/> page, as links render like so:

```https://www.selfdefined.app/definitions/add-adhd/%3Chttps://icd.who.int/browse11/l-m/en#/http%3a%2f%2fid.who.int%2ficd%2fentity%2f821852937%3E```

I hope removing the brackets fixes it!

## How Has This Been Tested?
I followed the format used in some other markdown files I saw, but haven't tested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
